### PR TITLE
Fix compatibility with dynesty>2.0.0, scipy and numpy

### DIFF
--- a/bajes/inf/sampler/dynesty.py
+++ b/bajes/inf/sampler/dynesty.py
@@ -227,6 +227,7 @@ class SamplerDynesty(SamplerBody):
         self.sampler    = self._initialize_sampler(like_fn,
                                                    ptform_fn,
                                                    proposals,
+                                                   dynesty.__version__,
                                                    sampler_kwargs)
 
     def _initialize_sampler(self, like_fn, ptform_fn, proposals, dynesty_version, kwargs):

--- a/bajes/inf/sampler/dynesty.py
+++ b/bajes/inf/sampler/dynesty.py
@@ -227,7 +227,6 @@ class SamplerDynesty(SamplerBody):
         self.sampler    = self._initialize_sampler(like_fn,
                                                    ptform_fn,
                                                    proposals,
-                                                   dynesty.__version__,
                                                    sampler_kwargs)
 
     def _initialize_sampler(self, like_fn, ptform_fn, proposals, dynesty_version, kwargs):
@@ -291,7 +290,7 @@ class SamplerDynesty(SamplerBody):
 
     def __update__(self):
 
-        (worst, ustar, vstar, loglstar, logvol, logwt, logz, logzvar, h, nc, worst_it, boundidx, bounditer, eff, delta_logz) = self._last_iter
+        (worst, ustar, vstar, loglstar, logvol, logwt, logz, logzvar, h, nc, worst_it, boundidx, bounditer, eff, delta_logz, blob) = self._last_iter
 
         args = {'it' :      self.sampler.it,
                 'eff' :     '{:.2f}%'.format(eff),
@@ -317,10 +316,10 @@ class SamplerDynesty(SamplerBody):
 
             this_params = list_2_dict(self.nested_samples[i], self.names)
             logpr       = self.log_prior_fn(this_params)
-            logl        = np.float(self.results.logl[i])
+            logl        = float(self.results.logl[i])
 
             ns.append(np.append(self.nested_samples[i], [logl, logpr]))
-            wt.append(np.float(self.results.logwt[i]-self.results.logz[-1]))
+            wt.append(float(self.results.logwt[i]-self.results.logz[-1]))
 
         ns      = np.array(ns)
         wt      = np.array(wt)

--- a/bajes/obs/gw/approx/nrpm.py
+++ b/bajes/obs/gw/approx/nrpm.py
@@ -98,7 +98,8 @@ def NRPM_TaperBeforeMerger( ti , Mtot , eta , f_merg , A_merg ):
 
 
 def NRPM(srate, seglen, Mtot, q, kappa2T, distance, inclination, phi_merg,
-         f_merg = None, alpha  = None, beta = None, phi_kick = None, recal = None):
+         f_merg = None, alpha  = None, beta = None, phi_kick = None, recal = None, 
+         output = False):
 
     deltaT      = 1./srate
     Npt         = int(seglen*srate)
@@ -162,25 +163,31 @@ def NRPM(srate, seglen, Mtot, q, kappa2T, distance, inclination, phi_merg,
     # initialize hs
     hplus   = np.zeros(Npt)
     hcross  = np.zeros(Npt)
+    h22     = np.zeros(Npt)
 
     # compute taper pre-merger
     amppre, phipre, dfreq = NRPM_TaperBeforeMerger(time[indspre], Mtot , q, fm, am)
     phipre -= phipre[-1] + phi_merg
     hplus[indspre]  = spherharm_norm*inc_plus*amppre*np.cos(phipre)/distance
     hcross[indspre] = spherharm_norm*inc_cross*amppre*np.sin(phipre)/distance
-
+    h22[indspre]    = amppre*np.exp(-1j*phipre)
+    
     phi_0 = phi_merg
     if t0 > 0:
         amp0 = NRPM_AmpModel_plus(time[inds0], am , a0 , 0.0 , t0 )
         phi0 = NRPM_PhaseModel0(time[inds0],fm,dfreq[-1],f1,t0) + phi_merg
         hplus[inds0]  = spherharm_norm*inc_plus*amp0*np.cos(phi0)/distance
         hcross[inds0] = spherharm_norm*inc_cross*amp0*np.sin(phi0)/distance
+        h22[inds0]    = amp0*np.exp(-1j*phi0)
         phi_0 += NRPM_PhaseModel0( t0, fm , dfreq[-1] , f1 , t0)
 
     # if kappa2T < 60, it is assumed that
     # no post-merger radiation occurs due to prompt collapse
     if kappa2T < 60 :
-        return hplus, hcross
+        if output:
+            return hplus, hcross, h22
+        else:
+            return hplus, hcross
 
     # additional phase-shift after merger
     if phi_kick == None:
@@ -192,6 +199,7 @@ def NRPM(srate, seglen, Mtot, q, kappa2T, distance, inclination, phi_merg,
         phi1 = NRPM_PhaseModel1(time[inds1], t0, f1) + phi_0
         hplus[inds1]  = spherharm_norm*inc_plus*amp1*np.cos(phi1)/distance
         hcross[inds1] = spherharm_norm*inc_cross*amp1*np.sin(phi1)/distance
+        h22[inds1]    = amp1*np.exp(-1j*phi1)
         phi_0 += NRPM_PhaseModel1(t1, t0, f1)
 
     if t2 > t1:
@@ -199,6 +207,7 @@ def NRPM(srate, seglen, Mtot, q, kappa2T, distance, inclination, phi_merg,
         phi2 = NRPM_PhaseModel2(time[inds2], f1 , f3 , t1, t2) + phi_0
         hplus[inds2]  = spherharm_norm*inc_plus*amp2*np.cos(phi2)/distance
         hcross[inds2] = spherharm_norm*inc_cross*amp2*np.sin(phi2)/distance
+        h22[inds2]    = amp2*np.exp(-1j*phi2)
         phi_0 += NRPM_PhaseModel2(t2, f1 , f3 , t1, t2)
 
     if t3 > t2:
@@ -206,14 +215,19 @@ def NRPM(srate, seglen, Mtot, q, kappa2T, distance, inclination, phi_merg,
         phi3 = NRPM_PhaseModel3(time[inds3], f2 , f3 , t2 , t3)  + phi_0
         hplus[inds3]  = spherharm_norm*inc_plus*amp3*np.cos(phi3)/distance
         hcross[inds3] = spherharm_norm*inc_cross*amp3*np.sin(phi3)/distance
+        h22[inds3]    = amp3*np.exp(-1j*phi3)
         phi_0 += NRPM_PhaseModel3(t3, f2 , f3 , t2 , t3)
 
     amp4 = NRPM_AmpModel_exp(time[inds4], am , a3 , t3 , tc , alpha)
     phi4 = NRPM_PhaseModel4(time[inds4], f2 , t3, beta) + phi_0
     hplus[inds4]  = spherharm_norm*inc_plus*amp4*np.cos(phi4)/distance
     hcross[inds4] = spherharm_norm*inc_cross*amp4*np.sin(phi4)/distance
+    h22[inds4]    = amp4*np.exp(-1j*phi4)
 
-    return hplus, hcross
+    if output:
+        return hplus, hcross, h22
+    else:
+        return hplus, hcross
 
 def nrpm_wrapper(freqs, params):
 

--- a/bajes/obs/gw/approx/nrpm.py
+++ b/bajes/obs/gw/approx/nrpm.py
@@ -163,7 +163,7 @@ def NRPM(srate, seglen, Mtot, q, kappa2T, distance, inclination, phi_merg,
     # initialize hs
     hplus   = np.zeros(Npt)
     hcross  = np.zeros(Npt)
-    h22     = np.zeros(Npt)
+    h22     = np.zeros(Npt, dtype=complex)
 
     # compute taper pre-merger
     amppre, phipre, dfreq = NRPM_TaperBeforeMerger(time[indspre], Mtot , q, fm, am)

--- a/bajes/obs/gw/strain.py
+++ b/bajes/obs/gw/strain.py
@@ -1,7 +1,6 @@
 from __future__ import division, unicode_literals, absolute_import
 import numpy as np
-from scipy.signal import tukey
-
+from scipy.signal.windows import tukey
 import logging
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Minor fixes to ensure compatibility with `dynesty`>2.0.0 as well as the more recent releases of numpy and scipy:
- Added `blob` to unpacking of `dynesty` results;
- fixed scipy import of `tukey` window function
- swapped instances of `np.float()` to `float`